### PR TITLE
Add database connection retry logic for cold-start scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Health check endpoints for Kubernetes/Railway
 - Automatic cleanup of old backups based on retention policy
 - Retry logic with exponential backoff
+- Enhanced database connection retry logic for cold-start scenarios
+- Configurable retry parameters for database connections and psql commands
 - Graceful shutdown handling
 - Panic recovery
 - Progress tracking for large backups

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A production-ready PostgreSQL backup service designed for Railway.app deployment
 - **Railway Integration**: Works seamlessly with Railway's cron feature
 - **Monitoring**: Prometheus metrics and health check endpoints
 - **Production Ready**: Retry logic, graceful shutdown, panic recovery
+- **Cold Start Support**: Automatic retries with exponential backoff for database connections
 - **Flexible Configuration**: Environment variable based configuration
 - **Backup Management**: Automatic cleanup of old backups based on retention policy
 - **PostgreSQL Version Support**: Automatically detects and uses the correct pg_dump version for PostgreSQL 15, 16, and 17
@@ -75,6 +76,20 @@ docker run -e DATABASE_URL=postgres://... \
 | `RESPAWN_PROTECTION_HOURS` | Minimum hours between backups | 23 |
 | `FORCE_BACKUP` | Skip respawn protection | false |
 | `RETENTION_DAYS` | Days to keep old backups | 0 (disabled) |
+
+### Database Connection Retry Configuration
+
+The service includes automatic retry logic for database connections to handle cold-start scenarios (e.g., when the database is still starting up).
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DB_RETRY_MAX_ATTEMPTS` | Maximum number of connection retry attempts | 10 |
+| `DB_RETRY_INITIAL_DELAY` | Initial delay between retries (seconds) | 2 |
+| `DB_RETRY_MAX_DELAY` | Maximum delay between retries (seconds) | 60 |
+| `DB_RETRY_BACKOFF_FACTOR` | Exponential backoff factor | 2.0 |
+| `PSQL_RETRY_MAX_ATTEMPTS` | Maximum retries for psql commands | 5 |
+| `PSQL_RETRY_INITIAL_DELAY` | Initial delay for psql retries (seconds) | 2 |
+| `PSQL_RETRY_MAX_DELAY` | Maximum delay for psql retries (seconds) | 30 |
 
 ### Monitoring Configuration
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The service includes automatic retry logic for database connections to handle co
 | `PSQL_RETRY_MAX_ATTEMPTS` | Maximum retries for psql commands | 5 |
 | `PSQL_RETRY_INITIAL_DELAY` | Initial delay for psql retries (seconds) | 2 |
 | `PSQL_RETRY_MAX_DELAY` | Maximum delay for psql retries (seconds) | 30 |
+| `HEALTH_CHECK_RETRY_MAX_ATTEMPTS` | Maximum retries for health checks | 3 |
+| `HEALTH_CHECK_RETRY_INITIAL_DELAY` | Initial delay for health check retries (seconds) | 1 |
+| `HEALTH_CHECK_RETRY_MAX_DELAY` | Maximum delay for health check retries (seconds) | 5 |
 
 ### Monitoring Configuration
 

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -82,13 +82,9 @@ func main() {
 		})
 
 		httpServer.RegisterHealthCheck("database", func(ctx context.Context) health.Check {
-			// Use connection pool with retry for health checks
-			pool, err := utils.NewConnectionPoolWithRetry(ctx, cfg.DatabaseURL, utils.RetryConfig{
-				MaxRetries:    3,               // Fewer retries for health checks
-				InitialDelay:  1 * time.Second, // Shorter initial delay
-				MaxDelay:      5 * time.Second, // Lower max delay for faster health checks
-				BackoffFactor: 2.0,
-			})
+			// Use connection pool with health check retry config
+			healthCheckRetryConfig := utils.HealthCheckRetryConfig()
+			pool, err := utils.NewConnectionPoolWithRetry(ctx, cfg.DatabaseURL, healthCheckRetryConfig)
 			if err != nil {
 				return health.Check{
 					Status:    health.StatusUnhealthy,

--- a/internal/backup/orchestrator.go
+++ b/internal/backup/orchestrator.go
@@ -83,10 +83,10 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	// Generate backup filename and key
 	timestamp := time.Now()
 	filename := utils.GenerateBackupFilename(o.config.BackupFilePrefix, timestamp, info.Version)
-	
+
 	// Create storage key with year/month directory structure
 	storageKey := fmt.Sprintf("%d/%02d/%s", timestamp.Year(), timestamp.Month(), filename)
-	
+
 	o.logger.Info("Generated backup filename", "filename", filename, "storage_key", storageKey)
 
 	// Create backup

--- a/internal/backup/pgversion.go
+++ b/internal/backup/pgversion.go
@@ -1,12 +1,16 @@
 package backup
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // PGVersion represents a PostgreSQL version
@@ -14,6 +18,70 @@ type PGVersion struct {
 	Major int
 	Minor int
 	Full  string
+}
+
+// RetryConfig holds configuration for command retries
+type RetryConfig struct {
+	MaxRetries    int           // Maximum number of retry attempts
+	InitialDelay  time.Duration // Initial delay between retries
+	MaxDelay      time.Duration // Maximum delay between retries
+	BackoffFactor float64       // Exponential backoff factor
+}
+
+// defaultPSQLRetryConfig returns the default retry configuration for psql commands
+func defaultPSQLRetryConfig() RetryConfig {
+	config := RetryConfig{
+		MaxRetries:    5,                // Fewer retries for psql commands
+		InitialDelay:  2 * time.Second,  // Start with 2 second delay
+		MaxDelay:      30 * time.Second, // Cap at 30 seconds
+		BackoffFactor: 2.0,              // Double the delay each time
+	}
+
+	// Override with environment variables if set
+	if maxRetries := os.Getenv("PSQL_RETRY_MAX_ATTEMPTS"); maxRetries != "" {
+		if val, err := strconv.Atoi(maxRetries); err == nil && val > 0 {
+			config.MaxRetries = val
+		}
+	}
+
+	if initialDelay := os.Getenv("PSQL_RETRY_INITIAL_DELAY"); initialDelay != "" {
+		if val, err := strconv.Atoi(initialDelay); err == nil && val > 0 {
+			config.InitialDelay = time.Duration(val) * time.Second
+		}
+	}
+
+	if maxDelay := os.Getenv("PSQL_RETRY_MAX_DELAY"); maxDelay != "" {
+		if val, err := strconv.Atoi(maxDelay); err == nil && val > 0 {
+			config.MaxDelay = time.Duration(val) * time.Second
+		}
+	}
+
+	return config
+}
+
+// isRetryableError checks if an error from psql command should trigger a retry
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check exit error
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		errOutput := string(exitErr.Stderr)
+		// Check for common retryable error messages
+		return strings.Contains(errOutput, "the database system is starting up") ||
+			strings.Contains(errOutput, "SQLSTATE 57P03") ||
+			strings.Contains(errOutput, "connection refused") ||
+			strings.Contains(errOutput, "could not connect to server") ||
+			strings.Contains(errOutput, "no such host") ||
+			strings.Contains(errOutput, "timeout expired")
+	}
+
+	// Check error message
+	errStr := err.Error()
+	return strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "timeout")
 }
 
 // ParsePGVersion parses a PostgreSQL version string
@@ -42,23 +110,84 @@ func ParsePGVersion(versionStr string) (*PGVersion, error) {
 	}, nil
 }
 
-// GetServerVersion gets the PostgreSQL server version
+// GetServerVersion gets the PostgreSQL server version with retry logic
 func GetServerVersion(ctx context.Context, connectionURL string) (*PGVersion, error) {
-	cmd := exec.CommandContext(ctx, "psql",
-		"--no-password",
-		"--tuples-only",
-		"--no-align",
-		"--command", "SELECT version();",
-		connectionURL,
-	)
+	return GetServerVersionWithRetry(ctx, connectionURL, defaultPSQLRetryConfig())
+}
 
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get server version: %w", err)
+// GetServerVersionWithRetry gets the PostgreSQL server version with configurable retry logic
+func GetServerVersionWithRetry(ctx context.Context, connectionURL string, retryConfig RetryConfig) (*PGVersion, error) {
+	logger := slog.Default().With("component", "pgversion")
+
+	var lastErr error
+	delay := retryConfig.InitialDelay
+
+	for attempt := 0; attempt <= retryConfig.MaxRetries; attempt++ {
+		if attempt > 0 {
+			logger.Info("Retrying PostgreSQL version check",
+				"attempt", attempt,
+				"max_retries", retryConfig.MaxRetries,
+				"delay", delay)
+
+			select {
+			case <-time.After(delay):
+				// Continue with retry
+			case <-ctx.Done():
+				return nil, fmt.Errorf("context cancelled during retry: %w", ctx.Err())
+			}
+
+			// Calculate next delay with exponential backoff
+			delay = time.Duration(float64(delay) * retryConfig.BackoffFactor)
+			if delay > retryConfig.MaxDelay {
+				delay = retryConfig.MaxDelay
+			}
+		}
+
+		cmd := exec.CommandContext(ctx, "psql",
+			"--no-password",
+			"--tuples-only",
+			"--no-align",
+			"--command", "SELECT version();",
+			connectionURL,
+		)
+
+		// Capture stderr for better error messages
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+
+		output, err := cmd.Output()
+		if err == nil {
+			versionStr := strings.TrimSpace(string(output))
+			version, parseErr := ParsePGVersion(versionStr)
+			if parseErr == nil {
+				if attempt > 0 {
+					logger.Info("Successfully retrieved PostgreSQL version",
+						"attempts", attempt+1,
+						"version", version.Full)
+				}
+				return version, nil
+			}
+			err = parseErr
+		} else if exitErr, ok := err.(*exec.ExitError); ok {
+			// Add stderr to the error for better debugging
+			exitErr.Stderr = stderr.Bytes()
+		}
+
+		lastErr = err
+
+		// Check if this is a connection error that we should retry
+		if isRetryableError(err) {
+			logger.Warn("Retryable error encountered",
+				"error", err,
+				"stderr", stderr.String())
+		} else {
+			// If it's not retryable, return immediately
+			return nil, fmt.Errorf("non-retryable error: %w (stderr: %s)", err, stderr.String())
+		}
 	}
 
-	versionStr := strings.TrimSpace(string(output))
-	return ParsePGVersion(versionStr)
+	return nil, fmt.Errorf("failed to get server version after %d retries: %w",
+		retryConfig.MaxRetries, lastErr)
 }
 
 // FindBestPGDump finds the best pg_dump binary for the given server version

--- a/internal/backup/pgversion.go
+++ b/internal/backup/pgversion.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"os/exec"
 	"regexp"
@@ -137,10 +138,8 @@ func GetServerVersionWithRetry(ctx context.Context, connectionURL string, retryC
 			}
 
 			// Calculate next delay with exponential backoff
-			delay = time.Duration(float64(delay) * retryConfig.BackoffFactor)
-			if delay > retryConfig.MaxDelay {
-				delay = retryConfig.MaxDelay
-			}
+			nextDelay := float64(delay) * retryConfig.BackoffFactor
+			delay = time.Duration(math.Min(nextDelay, float64(retryConfig.MaxDelay)))
 		}
 
 		cmd := exec.CommandContext(ctx, "psql",

--- a/internal/backup/pgversion_test.go
+++ b/internal/backup/pgversion_test.go
@@ -6,11 +6,11 @@ import (
 
 func TestParsePGVersion(t *testing.T) {
 	tests := []struct {
-		name        string
-		versionStr  string
-		wantMajor   int
-		wantMinor   int
-		wantErr     bool
+		name       string
+		versionStr string
+		wantMajor  int
+		wantMinor  int
+		wantErr    bool
 	}{
 		{
 			name:       "PostgreSQL 16.2",

--- a/internal/backup/pgversion_test.go
+++ b/internal/backup/pgversion_test.go
@@ -83,3 +83,28 @@ func TestFindBestPGDump(t *testing.T) {
 		}
 	})
 }
+
+func TestFindAvailablePSQL(t *testing.T) {
+	// This test verifies that findAvailablePSQL returns a psql binary
+	psqlBin := findAvailablePSQL()
+	
+	// Should always return at least "psql" as fallback
+	if psqlBin == "" {
+		t.Error("findAvailablePSQL returned empty string")
+	}
+	
+	// Log which binary was found
+	t.Logf("findAvailablePSQL returned: %s", psqlBin)
+	
+	// Verify it's one of the expected values
+	validBinaries := map[string]bool{
+		"psql":   true,
+		"psql15": true,
+		"psql16": true,
+		"psql17": true,
+	}
+	
+	if !validBinaries[psqlBin] {
+		t.Errorf("unexpected psql binary: %s", psqlBin)
+	}
+}

--- a/internal/backup/postgres.go
+++ b/internal/backup/postgres.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"os/exec"
 	"strings"
@@ -204,10 +205,8 @@ func (p *PostgresBackup) GetInfoWithRetry(ctx context.Context, retryConfig Retry
 			}
 
 			// Calculate next delay with exponential backoff
-			delay = time.Duration(float64(delay) * retryConfig.BackoffFactor)
-			if delay > retryConfig.MaxDelay {
-				delay = retryConfig.MaxDelay
-			}
+			nextDelay := float64(delay) * retryConfig.BackoffFactor
+			delay = time.Duration(math.Min(nextDelay, float64(retryConfig.MaxDelay)))
 		}
 
 		// Use psql to execute the query

--- a/internal/backup/postgres_test.go
+++ b/internal/backup/postgres_test.go
@@ -55,6 +55,27 @@ func TestNewPostgresBackup(t *testing.T) {
 					t.Errorf("pgDumpOptions[%d] = %v, want %v", i, opt, tt.wantOptions[i])
 				}
 			}
+			
+			// Verify psqlBin is set (should be set even before version detection)
+			if pb.psqlBin == "" {
+				t.Error("psqlBin is empty")
+			}
+			
+			// psqlBin should be one of the valid binaries
+			validPSQLBinaries := map[string]bool{
+				"psql":   true,
+				"psql15": true,
+				"psql16": true,
+				"psql17": true,
+			}
+			if !validPSQLBinaries[pb.psqlBin] {
+				t.Errorf("unexpected psqlBin: %s", pb.psqlBin)
+			}
+			
+			// pgDumpBin should also be set (either versioned or default)
+			if pb.pgDumpBin == "" {
+				t.Error("pgDumpBin is empty")
+			}
 		})
 	}
 }

--- a/internal/backup/retry_test.go
+++ b/internal/backup/retry_test.go
@@ -1,0 +1,88 @@
+package backup
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "exec.ExitError with database starting up",
+			err:      &exec.ExitError{Stderr: []byte("FATAL: the database system is starting up")},
+			expected: true,
+		},
+		{
+			name:     "exec.ExitError with SQLSTATE 57P03",
+			err:      &exec.ExitError{Stderr: []byte("ERROR: SQLSTATE 57P03")},
+			expected: true,
+		},
+		{
+			name:     "exec.ExitError with connection refused",
+			err:      &exec.ExitError{Stderr: []byte("psql: error: could not connect to server: Connection refused")},
+			expected: true,
+		},
+		{
+			name:     "exec.ExitError with no such host",
+			err:      &exec.ExitError{Stderr: []byte("psql: error: could not translate host name to address: no such host")},
+			expected: true,
+		},
+		{
+			name:     "exec.ExitError with timeout",
+			err:      &exec.ExitError{Stderr: []byte("psql: error: connection to server at \"localhost\", port 5432 failed: timeout expired")},
+			expected: true,
+		},
+		{
+			name:     "exec.ExitError with authentication failure",
+			err:      &exec.ExitError{Stderr: []byte("psql: error: password authentication failed")},
+			expected: false,
+		},
+		{
+			name:     "regular error with connection refused",
+			err:      errors.New("dial tcp 127.0.0.1:5432: connect: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "regular error with no retry pattern",
+			err:      errors.New("syntax error at or near"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRetryableError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isRetryableError(%v) = %v, expected %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultPSQLRetryConfig(t *testing.T) {
+	config := defaultPSQLRetryConfig()
+
+	if config.MaxRetries != 5 {
+		t.Errorf("expected MaxRetries to be 5, got %d", config.MaxRetries)
+	}
+	if config.InitialDelay != 2*time.Second {
+		t.Errorf("expected InitialDelay to be 2s, got %v", config.InitialDelay)
+	}
+	if config.MaxDelay != 30*time.Second {
+		t.Errorf("expected MaxDelay to be 30s, got %v", config.MaxDelay)
+	}
+	if config.BackoffFactor != 2.0 {
+		t.Errorf("expected BackoffFactor to be 2.0, got %f", config.BackoffFactor)
+	}
+}

--- a/internal/utils/pool.go
+++ b/internal/utils/pool.go
@@ -5,7 +5,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"net/url"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	_ "github.com/lib/pq" // PostgreSQL driver
@@ -16,8 +20,116 @@ type ConnectionPool struct {
 	db *sql.DB
 }
 
-// NewConnectionPool creates a new connection pool from a database URL.
+// RetryConfig holds configuration for database connection retries
+type RetryConfig struct {
+	MaxRetries    int           // Maximum number of retry attempts
+	InitialDelay  time.Duration // Initial delay between retries
+	MaxDelay      time.Duration // Maximum delay between retries
+	BackoffFactor float64       // Exponential backoff factor
+}
+
+// DefaultRetryConfig returns the default retry configuration
+// Can be overridden with environment variables:
+// - DB_RETRY_MAX_ATTEMPTS: Maximum number of retry attempts (default: 10)
+// - DB_RETRY_INITIAL_DELAY: Initial delay in seconds (default: 2)
+// - DB_RETRY_MAX_DELAY: Maximum delay in seconds (default: 60)
+// - DB_RETRY_BACKOFF_FACTOR: Exponential backoff factor (default: 2.0)
+func DefaultRetryConfig() RetryConfig {
+	config := RetryConfig{
+		MaxRetries:    10,               // Allow up to 10 retries
+		InitialDelay:  2 * time.Second,  // Start with 2 second delay
+		MaxDelay:      60 * time.Second, // Cap at 60 seconds
+		BackoffFactor: 2.0,              // Double the delay each time
+	}
+
+	// Override with environment variables if set
+	if maxRetries := os.Getenv("DB_RETRY_MAX_ATTEMPTS"); maxRetries != "" {
+		if val, err := strconv.Atoi(maxRetries); err == nil && val > 0 {
+			config.MaxRetries = val
+		}
+	}
+
+	if initialDelay := os.Getenv("DB_RETRY_INITIAL_DELAY"); initialDelay != "" {
+		if val, err := strconv.Atoi(initialDelay); err == nil && val > 0 {
+			config.InitialDelay = time.Duration(val) * time.Second
+		}
+	}
+
+	if maxDelay := os.Getenv("DB_RETRY_MAX_DELAY"); maxDelay != "" {
+		if val, err := strconv.Atoi(maxDelay); err == nil && val > 0 {
+			config.MaxDelay = time.Duration(val) * time.Second
+		}
+	}
+
+	if backoffFactor := os.Getenv("DB_RETRY_BACKOFF_FACTOR"); backoffFactor != "" {
+		if val, err := strconv.ParseFloat(backoffFactor, 64); err == nil && val > 1.0 {
+			config.BackoffFactor = val
+		}
+	}
+
+	return config
+}
+
+// NewConnectionPool creates a new connection pool from a database URL with default retry configuration.
 func NewConnectionPool(databaseURL string) (*ConnectionPool, error) {
+	return NewConnectionPoolWithRetry(context.Background(), databaseURL, DefaultRetryConfig())
+}
+
+// NewConnectionPoolWithRetry creates a new connection pool from a database URL with retry logic.
+func NewConnectionPoolWithRetry(ctx context.Context, databaseURL string, retryConfig RetryConfig) (*ConnectionPool, error) {
+	logger := slog.Default().With("component", "connection-pool")
+
+	var lastErr error
+	delay := retryConfig.InitialDelay
+
+	for attempt := 0; attempt <= retryConfig.MaxRetries; attempt++ {
+		if attempt > 0 {
+			logger.Info("Retrying database connection",
+				"attempt", attempt,
+				"max_retries", retryConfig.MaxRetries,
+				"delay", delay)
+
+			select {
+			case <-time.After(delay):
+				// Continue with retry
+			case <-ctx.Done():
+				return nil, fmt.Errorf("context cancelled during retry: %w", ctx.Err())
+			}
+
+			// Calculate next delay with exponential backoff
+			delay = time.Duration(float64(delay) * retryConfig.BackoffFactor)
+			if delay > retryConfig.MaxDelay {
+				delay = retryConfig.MaxDelay
+			}
+		}
+
+		pool, err := tryDatabaseConnection(ctx, databaseURL)
+		if err == nil {
+			if attempt > 0 {
+				logger.Info("Successfully connected to database",
+					"attempts", attempt+1)
+			}
+			return pool, nil
+		}
+
+		lastErr = err
+
+		// Check if this is a cold boot error
+		if isColdBootError(err) {
+			logger.Warn("Database appears to be cold booting",
+				"error", err)
+		} else {
+			logger.Error("Failed to connect to database",
+				"error", err)
+		}
+	}
+
+	return nil, fmt.Errorf("all database connection attempts failed after %d retries: %w",
+		retryConfig.MaxRetries, lastErr)
+}
+
+// tryDatabaseConnection attempts to connect to the database with the given URL
+func tryDatabaseConnection(ctx context.Context, databaseURL string) (*ConnectionPool, error) {
 	// Parse URL to add connection pool parameters
 	u, err := url.Parse(databaseURL)
 	if err != nil {
@@ -46,16 +158,33 @@ func NewConnectionPool(databaseURL string) (*ConnectionPool, error) {
 	db.SetConnMaxLifetime(5 * time.Minute)
 	db.SetConnMaxIdleTime(1 * time.Minute)
 
-	// Test connection
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Test connection with timeout
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	if err := db.PingContext(ctx); err != nil {
+	if err := db.PingContext(pingCtx); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
 	return &ConnectionPool{db: db}, nil
+}
+
+// isColdBootError checks if the error indicates the database is still starting up
+func isColdBootError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+	// Check for common cold boot error messages
+	return strings.Contains(errStr, "the database system is starting up") ||
+		strings.Contains(errStr, "SQLSTATE 57P03") ||
+		strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "ECONNREFUSED") ||
+		strings.Contains(errStr, "timeout") ||
+		strings.Contains(errStr, "dial tcp")
 }
 
 // GetDatabaseInfo retrieves database information.

--- a/internal/utils/pool.go
+++ b/internal/utils/pool.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/url"
 	"os"
 	"strconv"
@@ -97,10 +98,8 @@ func NewConnectionPoolWithRetry(ctx context.Context, databaseURL string, retryCo
 			}
 
 			// Calculate next delay with exponential backoff
-			delay = time.Duration(float64(delay) * retryConfig.BackoffFactor)
-			if delay > retryConfig.MaxDelay {
-				delay = retryConfig.MaxDelay
-			}
+			nextDelay := float64(delay) * retryConfig.BackoffFactor
+			delay = time.Duration(math.Min(nextDelay, float64(retryConfig.MaxDelay)))
 		}
 
 		pool, err := tryDatabaseConnection(ctx, databaseURL)

--- a/internal/utils/pool_integration_test.go
+++ b/internal/utils/pool_integration_test.go
@@ -1,0 +1,161 @@
+package utils
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestConnectionRetryIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		name           string
+		databaseURL    string
+		retryConfig    RetryConfig
+		expectedErr    string
+		expectSuccess  bool
+	}{
+		{
+			name:        "connection refused error triggers retry",
+			databaseURL: "postgres://user:pass@localhost:55432/testdb?sslmode=disable",
+			retryConfig: RetryConfig{
+				MaxRetries:    2,
+				InitialDelay:  100 * time.Millisecond,
+				MaxDelay:      500 * time.Millisecond,
+				BackoffFactor: 2.0,
+			},
+			expectedErr:   "all database connection attempts failed",
+			expectSuccess: false,
+		},
+		{
+			name:        "invalid host triggers retry",
+			databaseURL: "postgres://user:pass@invalid-host-that-does-not-exist:5432/testdb?sslmode=disable",
+			retryConfig: RetryConfig{
+				MaxRetries:    1,
+				InitialDelay:  100 * time.Millisecond,
+				MaxDelay:      200 * time.Millisecond,
+				BackoffFactor: 2.0,
+			},
+			expectedErr:   "all database connection attempts failed",
+			expectSuccess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			startTime := time.Now()
+			pool, err := NewConnectionPoolWithRetry(ctx, tt.databaseURL, tt.retryConfig)
+			elapsed := time.Since(startTime)
+
+			if tt.expectSuccess {
+				if err != nil {
+					t.Errorf("expected success but got error: %v", err)
+				} else {
+					defer pool.Close()
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error but got success")
+					pool.Close()
+				} else if !errors.Is(err, context.DeadlineExceeded) && !contains(err.Error(), tt.expectedErr) {
+					t.Errorf("expected error containing %q, got %v", tt.expectedErr, err)
+				}
+			}
+
+			// Verify retry delays were applied
+			expectedMinTime := time.Duration(tt.retryConfig.MaxRetries) * tt.retryConfig.InitialDelay
+			if elapsed < expectedMinTime/2 { // Allow some margin
+				t.Errorf("retries completed too quickly: %v < %v", elapsed, expectedMinTime)
+			}
+		})
+	}
+}
+
+func TestColdBootErrorDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "database starting up",
+			err:      &net.OpError{Err: errors.New("the database system is starting up")},
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      &net.OpError{Op: "dial", Err: errors.New("connect: connection refused")},
+			expected: true,
+		},
+		{
+			name:     "timeout error", 
+			err:      &net.OpError{Err: errors.New("i/o timeout")},
+			expected: true,
+		},
+		{
+			name:     "authentication error",
+			err:      errors.New("pq: password authentication failed"),
+			expected: false,
+		},
+		{
+			name:     "sql error",
+			err:      sql.ErrNoRows,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isColdBootError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isColdBootError(%v) = %v, expected %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRetryDelayProgression(t *testing.T) {
+	config := RetryConfig{
+		MaxRetries:    5,
+		InitialDelay:  100 * time.Millisecond,
+		MaxDelay:      1 * time.Second,
+		BackoffFactor: 2.0,
+	}
+
+	expectedDelays := []time.Duration{
+		0,                        // First attempt, no delay
+		100 * time.Millisecond,   // After 1st failure
+		200 * time.Millisecond,   // After 2nd failure
+		400 * time.Millisecond,   // After 3rd failure
+		800 * time.Millisecond,   // After 4th failure
+		1 * time.Second,          // After 5th failure (capped at max)
+	}
+
+	delay := config.InitialDelay
+	for i := 1; i < len(expectedDelays); i++ {
+		if i > 1 {
+			// Calculate next delay with exponential backoff
+			nextDelay := float64(delay) * config.BackoffFactor
+			delay = time.Duration(math.Min(nextDelay, float64(config.MaxDelay)))
+		}
+
+		if delay != expectedDelays[i] {
+			t.Errorf("attempt %d: expected delay %v, got %v", i, expectedDelays[i], delay)
+		}
+	}
+}
+
+// Helper function
+func contains(s, substr string) bool {
+	return len(substr) > 0 && len(s) >= len(substr) && s[0:len(substr)] == substr || len(s) > len(substr) && contains(s[1:], substr)
+}

--- a/internal/utils/pool_test.go
+++ b/internal/utils/pool_test.go
@@ -25,6 +25,23 @@ func TestDefaultRetryConfig(t *testing.T) {
 	}
 }
 
+func TestHealthCheckRetryConfig(t *testing.T) {
+	config := HealthCheckRetryConfig()
+
+	if config.MaxRetries != 3 {
+		t.Errorf("expected MaxRetries to be 3, got %d", config.MaxRetries)
+	}
+	if config.InitialDelay != 1*time.Second {
+		t.Errorf("expected InitialDelay to be 1s, got %v", config.InitialDelay)
+	}
+	if config.MaxDelay != 5*time.Second {
+		t.Errorf("expected MaxDelay to be 5s, got %v", config.MaxDelay)
+	}
+	if config.BackoffFactor != 2.0 {
+		t.Errorf("expected BackoffFactor to be 2.0, got %f", config.BackoffFactor)
+	}
+}
+
 func TestIsColdBootError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/utils/pool_test.go
+++ b/internal/utils/pool_test.go
@@ -1,0 +1,139 @@
+package utils
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDefaultRetryConfig(t *testing.T) {
+	config := DefaultRetryConfig()
+
+	if config.MaxRetries != 10 {
+		t.Errorf("expected MaxRetries to be 10, got %d", config.MaxRetries)
+	}
+	if config.InitialDelay != 2*time.Second {
+		t.Errorf("expected InitialDelay to be 2s, got %v", config.InitialDelay)
+	}
+	if config.MaxDelay != 60*time.Second {
+		t.Errorf("expected MaxDelay to be 60s, got %v", config.MaxDelay)
+	}
+	if config.BackoffFactor != 2.0 {
+		t.Errorf("expected BackoffFactor to be 2.0, got %f", config.BackoffFactor)
+	}
+}
+
+func TestIsColdBootError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "database starting up error",
+			err:      errors.New("FATAL: the database system is starting up"),
+			expected: true,
+		},
+		{
+			name:     "SQLSTATE 57P03 error",
+			err:      errors.New("ERROR: SQLSTATE 57P03"),
+			expected: true,
+		},
+		{
+			name:     "connection refused error",
+			err:      errors.New("dial tcp 127.0.0.1:5432: connect: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "no such host error",
+			err:      errors.New("dial tcp: lookup postgres.railway.internal: no such host"),
+			expected: true,
+		},
+		{
+			name:     "ECONNREFUSED error",
+			err:      errors.New("connect: ECONNREFUSED"),
+			expected: true,
+		},
+		{
+			name:     "timeout error",
+			err:      errors.New("context deadline exceeded (timeout)"),
+			expected: true,
+		},
+		{
+			name:     "regular error",
+			err:      errors.New("syntax error"),
+			expected: false,
+		},
+		{
+			name:     "authentication error",
+			err:      errors.New("password authentication failed"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isColdBootError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isColdBootError(%v) = %v, expected %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRetryConfigFromEnvironment(t *testing.T) {
+	// Save original environment values
+	originalMaxRetries := getEnv("DB_RETRY_MAX_ATTEMPTS")
+	originalInitialDelay := getEnv("DB_RETRY_INITIAL_DELAY")
+	originalMaxDelay := getEnv("DB_RETRY_MAX_DELAY")
+	originalBackoffFactor := getEnv("DB_RETRY_BACKOFF_FACTOR")
+
+	// Clean up environment after test
+	defer func() {
+		setEnv("DB_RETRY_MAX_ATTEMPTS", originalMaxRetries)
+		setEnv("DB_RETRY_INITIAL_DELAY", originalInitialDelay)
+		setEnv("DB_RETRY_MAX_DELAY", originalMaxDelay)
+		setEnv("DB_RETRY_BACKOFF_FACTOR", originalBackoffFactor)
+	}()
+
+	// Set test environment values
+	t.Setenv("DB_RETRY_MAX_ATTEMPTS", "5")
+	t.Setenv("DB_RETRY_INITIAL_DELAY", "1")
+	t.Setenv("DB_RETRY_MAX_DELAY", "30")
+	t.Setenv("DB_RETRY_BACKOFF_FACTOR", "1.5")
+
+	config := DefaultRetryConfig()
+
+	if config.MaxRetries != 5 {
+		t.Errorf("expected MaxRetries to be 5, got %d", config.MaxRetries)
+	}
+	if config.InitialDelay != 1*time.Second {
+		t.Errorf("expected InitialDelay to be 1s, got %v", config.InitialDelay)
+	}
+	if config.MaxDelay != 30*time.Second {
+		t.Errorf("expected MaxDelay to be 30s, got %v", config.MaxDelay)
+	}
+	if config.BackoffFactor != 1.5 {
+		t.Errorf("expected BackoffFactor to be 1.5, got %f", config.BackoffFactor)
+	}
+}
+
+// Helper functions for environment variable management
+func getEnv(key string) string {
+	val, _ := os.LookupEnv(key)
+	return val
+}
+
+func setEnv(key, value string) {
+	if value == "" {
+		os.Unsetenv(key)
+	} else {
+		os.Setenv(key, value)
+	}
+}


### PR DESCRIPTION
## Summary
- Implements retry logic with exponential backoff for database connections
- Adds configurable retry parameters via environment variables
- Enhances resilience for serverless environments where databases need time to start

## Changes
- Added `RetryConfig` struct with configurable retry parameters
- Implemented `NewConnectionPoolWithRetry()` with exponential backoff logic
- Added cold boot error detection for common database startup errors
- Enhanced `GetServerVersion()` and `GetInfo()` with retry capability
- Updated health checks to use retryable connections
- Added comprehensive unit tests for retry functionality
- Updated documentation with retry configuration options

## Configuration
New environment variables for retry configuration:
- `DB_RETRY_MAX_ATTEMPTS`: Maximum connection retry attempts (default: 10)
- `DB_RETRY_INITIAL_DELAY`: Initial delay in seconds (default: 2)
- `DB_RETRY_MAX_DELAY`: Maximum delay in seconds (default: 60)
- `DB_RETRY_BACKOFF_FACTOR`: Exponential backoff factor (default: 2.0)
- `PSQL_RETRY_MAX_ATTEMPTS`: Maximum retries for psql commands (default: 5)
- `PSQL_RETRY_INITIAL_DELAY`: Initial delay for psql retries (default: 2)
- `PSQL_RETRY_MAX_DELAY`: Maximum delay for psql retries (default: 30)

## Test plan
- [x] Unit tests for retry configuration
- [x] Unit tests for cold boot error detection
- [x] Unit tests for psql retry error detection
- [x] All existing tests pass
- [ ] Manual testing with a cold-starting database
- [ ] Verify retry behavior in Railway environment

🤖 Generated with [Claude Code](https://claude.ai/code)